### PR TITLE
feat: migrate from Cursor to VS Code and add opencode

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,6 +1,14 @@
 # keep-sorted start
+api\.githubcopilot\.com
+dns-analytics\.mcp\.cloudflare\.com
 file://
+learn\.microsoft\.com/api/mcp
 macos-defaults\.com
+mcp\.app\.wiz\.io
+mcp\.atlassian\.com
+mcp\.context7\.com
+mcp\.exa\.ai
+mcp\.grep\.app
 medium\.com
 mirrors\.rpmfusion\.org/.*/fedora/rpmfusion-.*-release-
 # keep-sorted end

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Configure my laptop with Ansible.
   * KeePassXC -> General ->
     * Automatically fill in single-credential entries
     * Allow filling HTTP Basic Auth credentials
-    * Show a banner on the page when new credentials can be saved to the database
+    * Show a banner on the page when new credentials can be saved to the
+      database
   * KeePassXC -> Connected Databases
 * Zoom
   * General -> Add Zoom to macOS menu bar
@@ -54,8 +55,8 @@ Configure my laptop with Ansible.
 
 * MacOS
   * Apple ID
-    * Disable synchronization of the Photos, iCloud Calendars, Reminders, Safari,
-      Stocks, ...
+    * Disable synchronization of the Photos, iCloud Calendars, Reminders,
+      Safari, Stocks, ...
   * Notifications
     * Allow notifications when the screen is locked
     * Slack -> Alerts

--- a/ansible/files/Users/myusername/Library/LaunchAgents/backup.plist.j2
+++ b/ansible/files/Users/myusername/Library/LaunchAgents/backup.plist.j2
@@ -14,7 +14,7 @@
     <key>StartCalendarInterval</key>
     <dict>
       <key>Hour</key>
-      <integer>1</integer>
+      <integer>0</integer>
       <key>Minute</key>
       <integer>0</integer>
     </dict>

--- a/ansible/files/home/myusername/.config/Code/User/settings.json
+++ b/ansible/files/home/myusername/.config/Code/User/settings.json
@@ -28,7 +28,7 @@
   // Editor window font size - https://stackoverflow.com/questions/33701933/how-to-change-environments-font-size
   "editor.fontSize": 14,
   // disable tooltip hint message - https://stackoverflow.com/questions/41115285/how-can-i-disable-hover-tooltip-hints-in-vs-code
-  "editor.hover.enabled": false,
+  "editor.hover.enabled": "off",
   // "editor.parameterHints.enabled": false,
   // "editor.quickSuggestions": {
   //   "other": "off"
@@ -63,8 +63,7 @@
   // https://timdeschryver.dev/blog/gain-control-over-commit-messages-generated-by-github-copilot
   "github.copilot.chat.commitMessageGeneration.instructions": [
     {
-      // "text": "Follow the Conventional Commits format for commit messages. Use the structure below:\n\n```\n<type>[optional scope]: <description>\n\n[optional body]\n```\n\nGuidelines:\n\n1. **Type and Scope**: Choose an appropriate type (e.g., `feat`, `fix`).\n\n2. **Description**: Write a concise, informative description in the header; use backticks if referencing code or specific terms.\n\n3. **Body**: For additional details, use a well-structured body section:\n   - Use bullet points (`*`) for clarity.\n   - Clearly describe the motivation, context, or technical details behind the change, if applicable.\n\nCommit messages should be clear, informative, and professional, aiding readability and project tracking and each line of the commit message can not exceed 80 characters."
-      "text": "Follow the Conventional Commits specification to create clear and consistent commit history. The number of commit message characters must not exceed 80."
+      "text": "Follow the Conventional Commits specification to create clear and consistent commit history. The number of commit message characters must not exceed 72."
     }
   ],
   "github.copilot.chat.pullRequestDescriptionGeneration.instructions": [
@@ -86,6 +85,8 @@
   "redhat.telemetry.enabled": true,
   // https://stackoverflow.com/questions/67914899/how-can-i-disable-workspace-trust-in-vs-code-1-57
   "security.workspace.trust.enabled": false,
+  // Allow keybindings to be sent to the shell in the integrated terminal
+  "terminal.integrated.sendKeybindingsToShell": true,
   // "terminal.integrated.env.osx": {
   //   "FIG_NEW_SESSION": "1"
   // },

--- a/ansible/files/home/myusername/.config/opencode/opencode.json
+++ b/ansible/files/home/myusername/.config/opencode/opencode.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "autoupdate": false,
+  "mcp": {
+    "atlassian-mcp-server": {
+      "enabled": false,
+      "type": "remote",
+      "url": "https://mcp.atlassian.com/v1/mcp"
+    },
+    "aws-knowledge-mcp-server": {
+      "enabled": false,
+      "type": "remote",
+      "url": "https://knowledge-mcp.global.api.aws"
+    },
+    "azure-knowledge": {
+      "enabled": false,
+      "type": "remote",
+      "url": "https://learn.microsoft.com/api/mcp"
+    },
+    "cloudflare-dns-analytics": {
+      "enabled": false,
+      "type": "remote",
+      "url": "https://dns-analytics.mcp.cloudflare.com/sse"
+    },
+    "context7.com": {
+      "type": "remote",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "exa.ai": {
+      "type": "remote",
+      "url": "https://mcp.exa.ai/mcp"
+    },
+    "github": {
+      "enabled": false,
+      "type": "remote",
+      "url": "https://api.githubcopilot.com/mcp/"
+    },
+    "grep.app": {
+      "type": "remote",
+      "url": "https://mcp.grep.app"
+    },
+    "kiwi.com": {
+      "enabled": false,
+      "type": "remote",
+      "url": "https://mcp.kiwi.com"
+    },
+    "wiz.io": {
+      "enabled": false,
+      "type": "remote",
+      "url": "https://mcp.app.wiz.io"
+    }
+  },
+  "instructions": ["AGENTS.md"],
+  "model": "github-copilot/claude-opus-4.6",
+  "plugin": [],
+  "share": "disabled"
+}

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -847,13 +847,13 @@
       value: '"mpv"'
     - section: types
       option: plain-text
-      value: '"Code"'
+      value: '"Visual Studio Code"'
     - section: types
       option: sourcecode
-      value: '"Code"'
+      value: '"Visual Studio Code"'
     - section: types
       option: text
-      value: '"Code"'
+      value: '"Visual Studio Code"'
     # keep-sorted end
   notify: Run infat
 

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -65,7 +65,6 @@
 - name: Install Homebrew casks
   community.general.homebrew_cask:
     name: "{{ homebrew_casks }}"
-    install_options: no-quarantine
 
 # https://www.mactrast.com/2017/03/show-status-bar-finder-macos-sierra/
 - name: Show status bar
@@ -435,8 +434,6 @@
       # Do not share history between sessions (like bash)
       setopt NO_SHARE_HISTORY
 
-      # Remove the quarantine flag when it installs a package
-      export HOMEBREW_CASK_OPTS="--no-quarantine"
       # Use bat for the brew cat command
       export HOMEBREW_BAT=1
       # Cleanup all cached files older than this many days

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -495,7 +495,7 @@
 
       export DELTA_PAGER="bat --style=plain"
       export EDITOR='nvim'
-      export SOPS_EDITOR='cursor --wait'
+      export SOPS_EDITOR='code --wait'
       export PAGER="bat --style=plain --paging=never"
 
       source "${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh"
@@ -676,11 +676,11 @@
       /.Trash
       /.cache
       /.colima
-      /.cursor
       /.gnupg/S.*
       /.krew
       /.lima
       /.local
+      /.vscode
       /Applications
       /Documents/chrome-extensions
       /Downloads
@@ -850,36 +850,20 @@
       value: '"mpv"'
     - section: types
       option: plain-text
-      value: '"Cursor"'
+      value: '"Code"'
     - section: types
       option: sourcecode
-      value: '"Cursor"'
+      value: '"Code"'
     - section: types
       option: text
-      value: '"Cursor"'
+      value: '"Code"'
     # keep-sorted end
   notify: Run infat
 
-- name: Create directory for aicommit2
-  ansible.builtin.file:
-    path: ~/Library/Application Support/aicommit2
-    state: directory
-    mode: u=rwx,g=rx,o=rx
-
-- name: Configure aicommit2
-  community.general.ini_file:
-    path: ~/Library/Application Support/aicommit2/config.ini
-    no_extra_spaces: true
-    option: "{{ item.option }}"
-    value: "{{ item.value }}"
-    mode: u=rw,g=r,o=r
-  loop:
-    # keep-sorted start
-    - option: logging
-      value: "false"
-    - option: maxLength
-      value: 72
-    # keep-sorted end
+- name: Copy opencode configuration
+  ansible.builtin.copy:
+    src: files/home/myusername/.config/opencode
+    dest: ~/.config/
 
 ################################################
 # Interactive (can not be "automated")

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -725,6 +725,8 @@
     skills add https://github.com/{{ item.repo }}
     --skill {{ item.skill }}
     --global --yes
+  args:
+    creates: ~/.agents/skills/{{ item.skill }}
   loop: "{{ code_opencode_agent_skills }}"
 
 ###################################################

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -633,20 +633,20 @@
       value: "false"
     # keep-sorted end
 
-- name: Put Cursor configuration in place
+- name: Put Code configuration in place
   ansible.builtin.copy:
-    src: files/home/myusername/.config/Cursor
+    src: files/home/myusername/.config/Code
     dest: "{% if ansible_facts['system'] == 'Darwin' %}~/Library/Application Support/{% else %}~/.config/{% endif %}"
     directory_mode: u=rwx,g=rx,o=rx
     mode: u=rw,g=r,o=r
 
-- name: Install the Cursor extensions
-  ansible.builtin.command: cursor --install-extension {{ item }}
+- name: Install the Code extensions
+  ansible.builtin.command: code --install-extension {{ item }}
   environment:
     PATH: /usr/local/bin:{{ ansible_facts['env']['PATH'] }}
   args:
-    creates: ~/.cursor/extensions/{{ item | lower }}*
-  loop: "{{ cursor_extensions }}"
+    creates: ~/.vscode/extensions/{{ item | lower }}*
+  loop: "{{ code_extensions }}"
 
 - name: Tweak sops
   ansible.builtin.blockinfile:
@@ -672,12 +672,12 @@
     mode: u=rwx,g=rx,o=rx
 
 - name: Place public ssh to autorized_key for root and {{ ansible_facts['user_id'] }}
-  ansible.posix.authorized_key:
-    user: "{{ ansible_facts['user_id'] }}"
-    key: https://github.com/{{ github_username }}.keys
+  ansible.builtin.blockinfile:
     path: "{{ ansible_facts['user_dir'] }}/.config/git/allowed_signers"
-    manage_dir: false
-    comment: "{{ email }}"
+    create: true
+    block: |
+      petr.ruzicka@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIF58juRs3gDSCFXARSXBBSegOmmBxXln9MVk2Zcq3HGh
+    mode: u=rw,g=r,o=r
 
 - name: Configure git
   ansible.builtin.copy:
@@ -719,6 +719,13 @@
     content: |
       plugin_cache_dir = "${HOME}/.terraform.d/plugin-cache"
     mode: u=rw,g=r,o=r
+
+- name: Add agent skills
+  ansible.builtin.command: >-
+    skills add https://github.com/{{ item.repo }}
+    --skill {{ item.skill }}
+    --global --yes
+  loop: "{{ code_opencode_agent_skills }}"
 
 ###################################################
 # Secrets

--- a/ansible/vars/Darwin.yml
+++ b/ansible/vars/Darwin.yml
@@ -15,7 +15,7 @@ homebrew_casks:
   - darktable
   - digikam
   - font-meslo-lg-nerd-font # Needed for iTerm2 + oh-my-zsh theme
-  - hiddenbar
+  - grammarly-desktop
   - home-assistant
   - iterm2
   - keepassxc
@@ -25,13 +25,15 @@ homebrew_casks:
   - mysides # Application for managing OS X Finder sidebar favorites
   - obs
   - stats
+  - thaw
   - utm
+  - visual-studio-code
   # keep-sorted end
 
 homebrew_packages:
   # keep-sorted start
   - ab-av1
-  - aicommit2
+  - actions-up
   - ansible
   - atuin
   - awscli
@@ -52,6 +54,7 @@ homebrew_packages:
   - exiftool
   - eza
   - fd
+  - fnox
   - fzf
   - gawk
   - gh
@@ -78,18 +81,19 @@ homebrew_packages:
   - midnight-commander
   - mise
   - mpg123 # needed for mc to display mp3 files
-  - nvim
+  - neovim
   - oh-my-posh
+  - opencode
   - opentofu
   - prek
   - prettier
-  - ratchet
   - rclone
   - rhash
   - rmtrash
   - rsync
   - shellcheck
   - shfmt
+  - skills
   - sops
   - telnet
   - tflint
@@ -120,7 +124,7 @@ login_items_enabled:
   - AltTab
   - KeePassXC
   - Stats
-  - hiddenbar
+  - Thaw
   # keep-sorted end
 
 login_picture_url: https://www.gravatar.com/avatar/{{ email | hash('md5') }}?s=500 # DevSkim: ignore DS126858

--- a/ansible/vars/common.yml
+++ b/ansible/vars/common.yml
@@ -1,6 +1,7 @@
 # keep-sorted start newline_separated=yes
 code_extensions:
   # keep-sorted start
+  - TakumiI.markdowntable
   - adamhartford.vscode-base64
   - antfu.slidev
   - bierner.markdown-mermaid
@@ -17,7 +18,6 @@ code_extensions:
   - rvben.rumdl
   - sst-dev.opencode
   - streetsidesoftware.code-spell-checker
-  - takumil.markdowntable
   - tyriar.sort-lines
   - yzhang.markdown-all-in-one
   # keep-sorted end

--- a/ansible/vars/common.yml
+++ b/ansible/vars/common.yml
@@ -1,10 +1,11 @@
 # keep-sorted start newline_separated=yes
-cursor_extensions:
+code_extensions:
   # keep-sorted start
   - adamhartford.vscode-base64
   - antfu.slidev
   - bierner.markdown-mermaid
   - bierner.markdown-preview-github-styles
+  - emanuelebartolesi.vscode-copilot-insights
   - esbenp.prettier-vscode
   - github.vscode-github-actions
   - github.vscode-pull-request-github
@@ -14,9 +15,23 @@ cursor_extensions:
   - pkief.material-icon-theme
   - redhat.vscode-yaml
   - rvben.rumdl
+  - sst-dev.opencode
   - streetsidesoftware.code-spell-checker
+  - takumil.markdowntable
   - tyriar.sort-lines
   - yzhang.markdown-all-in-one
+  # keep-sorted end
+
+code_opencode_agent_skills:
+  # keep-sorted start block=yes
+  - repo: anthropics/skills
+    skill: skill-creator
+  - repo: antonbabenko/terraform-skill
+    skill: terraform-skill
+  - repo: github/awesome-copilot
+    skill: git-commit
+  - repo: hashicorp/agent-skills
+    skill: terraform-style-guide
   # keep-sorted end
 
 # Directory where there are all the data (usually $HOME)


### PR DESCRIPTION
## Summary

- Migrate from Cursor editor to Visual Studio Code across all
  configurations (settings, extensions, CLI references, default
  application associations)
- Add opencode CLI tool with MCP server configuration and agent skills
  (skill-creator, terraform, git-commit, terraform-style-guide)
- Replace aicommit2 with opencode for commit message generation
- Replace hiddenbar with Thaw, add grammarly-desktop as new cask
- Add new homebrew packages: actions-up, fnox, skills, visual-studio-code
- Rename nvim to neovim homebrew package
- Change backup LaunchAgent schedule from 1am to midnight
- Fix git allowed_signers to use blockinfile instead of authorized_key
- Update README markdown line wrapping for compliance