### PR TITLE
chore: remove sops config and update skills install command

### DIFF
--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -492,7 +492,6 @@
 
       export DELTA_PAGER="bat --style=plain"
       export EDITOR='nvim'
-      export SOPS_EDITOR='code --wait'
       export PAGER="bat --style=plain --paging=never"
 
       source "${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh"
@@ -520,10 +519,6 @@
 
       # Configure DOCKER_HOST for app
       export DOCKER_HOST=unix://$HOME/.colima/docker.sock
-
-      # SOPS: Secrets OPerationS
-      export SOPS_AGE_KEY_FILE="${HOME}/Documents/secrets/age.txt"
-      export SOPS_AGE_RECIPIENTS="age1jjuamrdk3vrk6g8qhrjnqtt4x2yvvxw7fz2nkvf78398dj7vav7s74z4zz"
 
       zstyle ':completion:*' format $'\e[2;37mCompleting %d\e[m'
       source <(carapace _carapace)

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -648,16 +648,6 @@
     creates: ~/.vscode/extensions/{{ item | lower }}*
   loop: "{{ code_extensions }}"
 
-- name: Tweak sops
-  ansible.builtin.blockinfile:
-    dest: ~/.sops.yaml
-    create: true
-    block: |
-      stores:
-        yaml:
-          indent: 2
-    mode: u=rw,g=r,o=r
-
 - name: Configure .forward to {{ email }}
   ansible.builtin.copy:
     dest: ~/.forward
@@ -701,16 +691,14 @@
   ansible.builtin.copy:
     dest: ~/.config/mise/config.toml
     content: |
-      [env]
-      _.file = "~/Documents/secrets/.env.yaml"
+      [tools]
+      "npm:markdown-spellcheck" = "latest"
+      "npm:markdown-table-formatter" = "latest"
 
       [settings]
-      experimental = true
-      sops.age_key_file = "~/Documents/secrets/age.txt"
-
-      [tools]
-      "npm:@slidev/cli" = "latest"
-      "npm:markdown-spellcheck" = "latest"
+      env_cache = true
+      env_cache_ttl = "12h"
+      trusted_config_paths = ["/"]
     mode: u=rw,g=r,o=r
 
 - name: Configure terraform
@@ -722,9 +710,9 @@
 
 - name: Add agent skills
   ansible.builtin.command: >-
-    skills add https://github.com/{{ item.repo }}
-    --skill {{ item.skill }}
-    --global --yes
+    gh skill install {{ item.repo }}
+    {{ item.skill }}
+    --agent warp --scope user
   args:
     creates: ~/.agents/skills/{{ item.skill }}
   loop: "{{ code_opencode_agent_skills }}"

--- a/ansible/vars/Darwin.yml
+++ b/ansible/vars/Darwin.yml
@@ -93,8 +93,6 @@ homebrew_packages:
   - rsync
   - shellcheck
   - shfmt
-  - skills
-  - sops
   - telnet
   - tflint
   - tfupdate


### PR DESCRIPTION
## Summary

- Remove SOPS-related configuration (editor, age key, `.sops.yaml`, env vars)
  and `sops`/`skills` homebrew packages
- Update mise config: drop secrets/sops integration, add `env_cache` settings
  and `markdown-table-formatter`
- Update agent skills install to use `gh skill install` syntax