### PR TITLE
chore: update opencode agent skills configuration

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -51,13 +51,15 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          client-id: ${{ secrets.MY_RENOVATE_GITHUB_APP_ID }}
+          client-id: ${{ secrets.MY_RENOVATE_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.MY_RENOVATE_GITHUB_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
           permission-issues: write
           permission-checks: read
           permission-metadata: read
+          permission-statuses: write
+          permission-workflows: write
 
       - name: 💡 Self-hosted Renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -6,8 +6,7 @@ name: semantic-pull-request
 
 on:
   workflow_dispatch:
-  # zizmor: ignore[dangerous-triggers] - only reads PR metadata, no code checkout
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
@@ -24,4 +23,4 @@ jobs:
       - name: Validate semantic pull request title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@ __pycache__/
 
 # Ansible temporary files
 ansible/.ansible/
+
+# Ansible vault password file
+vault-*.password
 # keep-sorted end

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -6,6 +6,10 @@
 # and in individual linters documentation
 
 # keep-sorted start newline_separated=yes
+# Allow zizmor (GitHub Actions security scanner) to access GitHub token
+ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
+  - GITHUB_TOKEN
+
 ANSIBLE_ANSIBLE_LINT_CONFIG_FILE: ansible/.ansible-lint
 
 ANSIBLE_ANSIBLE_LINT_PRE_COMMANDS:
@@ -25,7 +29,7 @@ BASH_SHFMT_ARGUMENTS: --case-indent --indent 2 --space-redirects
 DISABLE_LINTERS:
   - MARKDOWN_MARKDOWNLINT # Using rumdl instead (faster Rust-based alternative)
   - MARKDOWN_MARKDOWN_LINK_CHECK # Using lychee instead for link checking (more configurable)
-  - REPOSITORY_OSV_SCANNER # No package sources in this repo
+  - REPOSITORY_OSV_SCANNER # No package sources in this repo - causes false failures
   - SPELL_CSPELL # Spell checking disabled - prone to false positives
   - TERRAFORM_TERRASCAN # Hard to configure - no clear documentation of the config file format
 
@@ -68,16 +72,8 @@ REPOSITORY_DEVSKIM_ARGUMENTS: --ignore-globs CHANGELOG.md --ignore-rule-ids DS16
 # Trivy (vulnerability scanner) - only check HIGH and CRITICAL severity
 REPOSITORY_TRIVY_ARGUMENTS: --severity HIGH,CRITICAL --ignore-unfixed
 
-# Allow zizmor (GitHub Actions security scanner) to access GitHub token
-ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
-  - GITHUB_TOKEN
-
 # Allow lychee (link checker) to access GitHub token for API rate limits
 SPELL_LYCHEE_UNSECURED_ENV_VARIABLES:
-  - GITHUB_TOKEN
-
-# Allow tflint (Terraform linter) to access GitHub token for plugin downloads
-TERRAFORM_TFLINT_UNSECURED_ENV_VARIABLES:
   - GITHUB_TOKEN
 
 # Prettier (TypeScript/JavaScript formatter) configuration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,116 +1,158 @@
-# Repo Guide for AI Agents
+# AI Agent Guidelines
 
-Ansible repo that configures the maintainer's personal workstations
-(macOS + Fedora). YAML, Bash, Jinja2. Generic conventions live in
-`~/.config/opencode/AGENTS.md`; only repo-specific guidance is below.
+## Overview
 
-## Layout
+Ansible repository that configures personal workstations (macOS and
+Fedora Linux). Primary languages: YAML (Ansible), Bash, Jinja2.
 
-- `ansible/main.yml` — single playbook entrypoint. Includes
-  `vars/<system>.yml` (`Darwin`/`Linux`) then runs
-  `tasks/<distribution>.yml` (`MacOSX.yml`/`Fedora.yml`) then
-  `tasks/common.yml`.
-- `ansible/tasks/` — three large monolithic task files
-  (`common.yml` ~790 lines, `Fedora.yml` ~1080, `MacOSX.yml` ~880).
-  No roles. Add new tasks inline in the matching OS file or
-  `common.yml`.
-- `ansible/vars/` — `common.yml` (shared), `Darwin.yml` (macOS),
-  `Linux.yml` (Fedora), `secrets.yml.vault` (vault-encrypted).
-- `ansible/files/{Users,home,etc}/` — files copied to target;
-  `Users/` is macOS, `home/` is Linux. Source path under
-  `myusername/` is templated at runtime.
-- `ansible/handlers/handlers.yml` — all handlers.
-- `ansible/ansible.cfg` — sets
-  `vault_password_file = vault-my_workstation.password`
-  (gitignored, must exist before running).
-- `scripts/`, `kickstart_file/` — Fedora ISO rebuild bits, not
-  part of the playbook run.
-
-## Running
-
-All `run_ansible_my_workstation*.sh` wrappers `cd ansible` first.
+## Build / Lint / Test Commands
 
 ```bash
-# Local macOS run (matches the maintainer's flow)
-./run_ansible_my_workstation-local-mac.sh   # edit MY_PASSWORD first
+# Install Ansible Galaxy dependencies
+ansible-galaxy install -r ansible/requirements.yml
 
-# Plain local run (no vault password needed if file is present)
-./run_ansible_my_workstation-local.sh
+# Run playbook locally (macOS)
+cd ansible || exit
+ansible-playbook --connection=local -i "127.0.0.1," main.yml
 
-# CI-equivalent run (no secrets, no interactive, no large data)
+# Run playbook skipping certain tags (CI mode)
 ansible-playbook --skip-tags data,interactive,secrets,skip_test \
-  --connection=local -i "127.0.0.1," ansible/main.yml
+  --connection=local -i "127.0.0.1," main.yml
 
-# Idempotence check: re-run with the same skip-tags and expect
-# `changed=0.*failed=0` (CI greps for this exact pattern).
+# Run a single tagged subset of tasks
+ansible-playbook --tags mc --connection=local -i "127.0.0.1," main.yml
 
-# Single feature subset
-ansible-playbook --tags mc --connection=local -i "127.0.0.1," ansible/main.yml
+# Lint Ansible files
+ansible-lint -c ansible/.ansible-lint.yml ansible/
+
+# Lint shell scripts
+shellcheck --exclude=SC2317 run_ansible_my_workstation*.sh
+shfmt --case-indent --indent 2 --space-redirects -d run_ansible_my_workstation*.sh
+
+# Lint Markdown
+rumdl .
+
+# Check links
+lychee --config lychee.toml .
+
+# Validate GitHub Actions workflows
+actionlint
+
+# Full CI linting (requires Docker)
+mega-linter-runner --flavor documentation
 ```
 
-Before any local run: create `ansible/vault-my_workstation.password`
-(plain text, one line). CI writes `"test_password"` into it.
+## Ansible Conventions
 
-## Tags (used to gate CI and selective runs)
+- **FQCN required**: Always use fully qualified collection names
+  (e.g., `ansible.builtin.copy`, `community.general.ini_file`),
+  never short names like `copy` or `file`
+- **Collections**: `ansible.builtin`, `ansible.posix`,
+  `community.general` (defined in `ansible/requirements.yml`)
+- **Task naming**: Every task must have a descriptive `name:` field
+- **File modes**: Use symbolic notation (`mode: u=rw,g=r,o=r`)
+  not octal (`mode: "0644"`)
+- **Become**: Use `become: true` in block-level when multiple tasks
+  need root, or per-task when only one does
+- **Tags**: Use tags for selective execution and test control:
+  - `secrets` - tasks using vault-encrypted variables
+  - `data` - tasks involving large data operations
+  - `interactive` - tasks requiring user input
+  - `skip_test` - tasks that should not run in CI
+  - `skip_idempotence_test` - tasks that are not idempotent
+  - Feature-specific tags: `mc`, `printer`, etc.
+- **Variables**: Define in `ansible/vars/common.yml` (shared),
+  `ansible/vars/Darwin.yml` (macOS), `ansible/vars/Linux.yml`
+  (Fedora)
+- **OS-specific tasks**: `ansible/tasks/MacOSX.yml` (macOS),
+  `ansible/tasks/Fedora.yml` (Fedora), `ansible/tasks/common.yml`
+  (shared)
+- **ansible-lint skips**: `package-latest`, `yaml[comments]`,
+  `yaml[document-start]`, `yaml[line-length]`
 
-- `secrets` — uses vault-encrypted vars. Skipped in CI.
-- `data` — large data ops (backups, restores). Skipped in CI.
-- `interactive` — needs user input. Skipped in CI.
-- `skip_test` — never run in CI for any reason.
-- `skip_idempotence_test` — runs first CI pass but skipped on the
-  second idempotence pass (use for tasks that legitimately change
-  every run).
-- Feature tags (`mc`, `printer`, …) — for ad-hoc selective runs.
+## Sorted Lists
 
-Tag every new task that fits these buckets, or CI will fail
-idempotence or break.
+This repo uses `# keep-sorted start` / `# keep-sorted end` comments
+to maintain alphabetical ordering in YAML lists, config blocks, and
+variable definitions. Always preserve these markers and keep items
+sorted alphabetically within them.
 
-## Ansible conventions (enforced)
+## Shell Scripts
 
-- **FQCN only**: `ansible.builtin.copy`, `community.general.ini_file`,
-  etc. Short names will fail `ansible-lint`.
-- Collections pinned in `ansible/requirements.yml`:
-  `ansible.posix`, `community.general`. Install with
-  `ansible-galaxy install -r ansible/requirements.yml`.
-- **File modes are symbolic**: `mode: u=rw,g=r,o=r`, never `"0644"`.
-- Every task needs a descriptive `name:`.
-- `ansible-lint` config at `ansible/.ansible-lint.yml` skips
-  `package-latest`, `yaml[comments]`, `yaml[document-start]`,
-  `yaml[line-length]` — do not rely on line-length wrapping in YAML.
-- Lint command: `ansible-lint -c ansible/.ansible-lint.yml ansible/`
+- **Linting**: Must pass `shellcheck` (SC2317 excluded)
+- **Formatting**: `shfmt --case-indent --indent 2 --space-redirects`
+- **Variables**: Use uppercase with braces (`${MY_VARIABLE}`)
+- **Indentation**: 2 spaces, no tabs
 
-## `keep-sorted` blocks
+## Markdown Files
 
-Keep-sorted `start` / `end` comment markers appear in YAML
-lists, var blocks, and `ansible.cfg`. Insertions must stay
-alphabetically sorted within the markers; do not remove the markers.
+- Must pass `rumdl` checks (`CHANGELOG.md` excluded)
+- Wrap lines at 80 characters
+- Use proper heading hierarchy (no skipped levels)
+- Include language identifiers in code fences
+- Shell code blocks must also pass `shellcheck` and `shfmt`
 
-## CI specifics
+## JSON Files
 
-- `.github/workflows/macos.yml` runs on every push (not main) that
-  touches `ansible/{files,handlers,main.yml,tasks/{MacOSX,common}.yml,vars/{Darwin,common}.yml}`
-  or the workflow itself. Runs the playbook twice (apply +
-  idempotence) and fails if the second run reports any changes.
-- `.github/workflows/fedora.yml` is `workflow_dispatch` only
-  (push trigger commented out) — uses Vagrant + VirtualBox on
-  `macos-15`.
-- Full local lint pass mirroring CI: `mega-linter-runner --flavor documentation`
-  (requires Docker).
+- Must pass `jsonlint --comments` validation
+- `.devcontainer/devcontainer.json` is excluded from linting
 
-## Shell wrappers
+## Link Checking
 
-The `run_ansible_my_workstation*.sh` scripts use `set -eux` and
-`cd ansible || exit`. Keep them small; real logic belongs in
-playbooks. Lint with
-`shellcheck --exclude=SC2317` and
-`shfmt --case-indent --indent 2 --space-redirects`.
+- `lychee` validates URLs (config in `lychee.toml`)
+- Accepts status codes 200 and 429
+- Excludes `CHANGELOG.md`, private IPs, template variables
 
-## Things not to do
+## Security Scanning
 
-- Don't add roles or restructure into multiple plays — current
-  design is intentionally one play, three task files.
-- Don't commit `ansible/vault-my_workstation.password` (gitignored).
-- Don't use octal file modes or short module names — lint will
-  fail.
-- Don't add tasks that change on every run without
-  `skip_idempotence_test` — CI macos job will fail.
+- **Checkov**: IaC scanner (skips `CKV_GHA_7`)
+- **DevSkim**: Pattern scanner (ignores DS162092, DS137138)
+- **Trivy**: HIGH/CRITICAL severity, ignores unfixed
+
+## GitHub Actions
+
+- Pin actions to full SHA commits, never tags
+- Use minimal permissions (`permissions: read-all`)
+- Validate changes with `actionlint`
+
+## Version Control
+
+### Commit Messages
+
+Conventional commit format: `<type>: <description>`
+
+- Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`,
+  `style`, `perf`, `ci`, `build`, `revert`
+- Subject: imperative mood, lowercase, no period, max 72 chars
+- Body: wrap at 72 chars, explain what and why
+- Reference issues: `Fixes`, `Closes`, `Resolves`
+
+```text
+feat: add automated dependency updates
+
+- Implement Dependabot configuration
+- Configure weekly security updates
+
+Resolves: #123
+```
+
+### Branching
+
+Follow conventional branch format: `<type>/<description>`
+
+- `feature/` or `feat/`, `bugfix/` or `fix/`, `hotfix/`,
+  `release/`, `chore/`
+- Lowercase, hyphens only, no consecutive/trailing hyphens
+
+### Pull Requests
+
+- Always create as **draft** initially
+- Title must follow conventional commit format
+- Include clear description and link related issues
+
+## General Style
+
+- **Indentation**: 2 spaces everywhere (YAML, shell, JSON)
+- **No tabs**: Spaces only in all files
+- **Formatting**: Consistent formatting across all file types
+- **Atomic commits**: One logical change per commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,158 +1,118 @@
-# AI Agent Guidelines
+# Repo Guide for AI Agents
 
-## Overview
+Ansible repo that configures the maintainer's personal workstations
+(macOS + Fedora). YAML, Bash, Jinja2. Generic conventions live in
+`~/.config/opencode/AGENTS.md`; only repo-specific guidance is below.
 
-Ansible repository that configures personal workstations (macOS and
-Fedora Linux). Primary languages: YAML (Ansible), Bash, Jinja2.
+## Layout
 
-## Build / Lint / Test Commands
+- `ansible/main.yml` — single playbook entrypoint. Includes
+  `vars/<system>.yml` (`Darwin`/`Linux`) then runs
+  `tasks/<distribution>.yml` (`MacOSX.yml`/`Fedora.yml`) then
+  `tasks/common.yml`.
+- `ansible/tasks/` — three large monolithic task files
+  (`common.yml` ~790 lines, `Fedora.yml` ~1080, `MacOSX.yml` ~880).
+  No roles. Add new tasks inline in the matching OS file or
+  `common.yml`.
+- `ansible/vars/` — `common.yml` (shared), `Darwin.yml` (macOS),
+  `Linux.yml` (Fedora), `secrets.yml.vault` (vault-encrypted).
+- `ansible/files/{Users,home,etc}/` — files copied to target;
+  `Users/` is macOS, `home/` is Linux. Source path under
+  `myusername/` is templated at runtime.
+- `ansible/handlers/handlers.yml` — all handlers.
+- `ansible/ansible.cfg` — sets
+  `vault_password_file = vault-my_workstation.password`
+  (gitignored, must exist before running).
+- `scripts/`, `kickstart_file/` — Fedora ISO rebuild bits, not
+  part of the playbook run.
+
+## Running
+
+All `run_ansible_my_workstation*.sh` wrappers `cd ansible` first.
 
 ```bash
-# Install Ansible Galaxy dependencies
-ansible-galaxy install -r ansible/requirements.yml
+# Local macOS run (matches the maintainer's flow)
+./run_ansible_my_workstation-local-mac.sh   # edit MY_PASSWORD first
 
-# Run playbook locally (macOS)
-cd ansible || exit
-ansible-playbook --connection=local -i "127.0.0.1," main.yml
+# Plain local run (no vault password needed if file is present)
+./run_ansible_my_workstation-local.sh
 
-# Run playbook skipping certain tags (CI mode)
+# CI-equivalent run (no secrets, no interactive, no large data)
 ansible-playbook --skip-tags data,interactive,secrets,skip_test \
-  --connection=local -i "127.0.0.1," main.yml
+  --connection=local -i "127.0.0.1," ansible/main.yml
 
-# Run a single tagged subset of tasks
-ansible-playbook --tags mc --connection=local -i "127.0.0.1," main.yml
+# Idempotence check: re-run with the same skip-tags and expect
+# `changed=0.*failed=0` (CI greps for this exact pattern).
 
-# Lint Ansible files
-ansible-lint -c ansible/.ansible-lint.yml ansible/
-
-# Lint shell scripts
-shellcheck --exclude=SC2317 run_ansible_my_workstation*.sh
-shfmt --case-indent --indent 2 --space-redirects -d run_ansible_my_workstation*.sh
-
-# Lint Markdown
-rumdl .
-
-# Check links
-lychee --config lychee.toml .
-
-# Validate GitHub Actions workflows
-actionlint
-
-# Full CI linting (requires Docker)
-mega-linter-runner --flavor documentation
+# Single feature subset
+ansible-playbook --tags mc --connection=local -i "127.0.0.1," ansible/main.yml
 ```
 
-## Ansible Conventions
+Before any local run: create `ansible/vault-my_workstation.password`
+(plain text, one line). CI writes `"test_password"` into it.
 
-- **FQCN required**: Always use fully qualified collection names
-  (e.g., `ansible.builtin.copy`, `community.general.ini_file`),
-  never short names like `copy` or `file`
-- **Collections**: `ansible.builtin`, `ansible.posix`,
-  `community.general` (defined in `ansible/requirements.yml`)
-- **Task naming**: Every task must have a descriptive `name:` field
-- **File modes**: Use symbolic notation (`mode: u=rw,g=r,o=r`)
-  not octal (`mode: "0644"`)
-- **Become**: Use `become: true` in block-level when multiple tasks
-  need root, or per-task when only one does
-- **Tags**: Use tags for selective execution and test control:
-  - `secrets` - tasks using vault-encrypted variables
-  - `data` - tasks involving large data operations
-  - `interactive` - tasks requiring user input
-  - `skip_test` - tasks that should not run in CI
-  - `skip_idempotence_test` - tasks that are not idempotent
-  - Feature-specific tags: `mc`, `printer`, etc.
-- **Variables**: Define in `ansible/vars/common.yml` (shared),
-  `ansible/vars/Darwin.yml` (macOS), `ansible/vars/Linux.yml`
-  (Fedora)
-- **OS-specific tasks**: `ansible/tasks/MacOSX.yml` (macOS),
-  `ansible/tasks/Fedora.yml` (Fedora), `ansible/tasks/common.yml`
-  (shared)
-- **ansible-lint skips**: `package-latest`, `yaml[comments]`,
-  `yaml[document-start]`, `yaml[line-length]`
+## Tags (used to gate CI and selective runs)
 
-## Sorted Lists
+- `secrets` — uses vault-encrypted vars. Skipped in CI.
+- `data` — large data ops (backups, restores). Skipped in CI.
+- `interactive` — needs user input. Skipped in CI.
+- `skip_test` — never run in CI for any reason.
+- `skip_idempotence_test` — runs first CI pass but skipped on the
+  second idempotence pass (use for tasks that legitimately change
+  every run).
+- Feature tags (`mc`, `printer`, …) — for ad-hoc selective runs.
 
-This repo uses `# keep-sorted start` / `# keep-sorted end` comments
-to maintain alphabetical ordering in YAML lists, config blocks, and
-variable definitions. Always preserve these markers and keep items
-sorted alphabetically within them.
+Tag every new task that fits these buckets, or CI will fail
+idempotence or break.
 
-## Shell Scripts
+## Ansible conventions (enforced)
 
-- **Linting**: Must pass `shellcheck` (SC2317 excluded)
-- **Formatting**: `shfmt --case-indent --indent 2 --space-redirects`
-- **Variables**: Use uppercase with braces (`${MY_VARIABLE}`)
-- **Indentation**: 2 spaces, no tabs
+- **FQCN only**: `ansible.builtin.copy`, `community.general.ini_file`,
+  etc. Short names will fail `ansible-lint`.
+- Collections pinned in `ansible/requirements.yml`:
+  `ansible.posix`, `community.general`. Install with
+  `ansible-galaxy install -r ansible/requirements.yml`.
+- **File modes are symbolic**: `mode: u=rw,g=r,o=r`, never `"0644"`.
+- Every task needs a descriptive `name:`.
+- `ansible-lint` config at `ansible/.ansible-lint.yml` skips
+  `package-latest`, `yaml[comments]`, `yaml[document-start]`,
+  `yaml[line-length]` — do not rely on line-length wrapping in YAML.
+- Lint command: `ansible-lint -c ansible/.ansible-lint.yml ansible/`
 
-## Markdown Files
+## `keep-sorted` blocks
 
-- Must pass `rumdl` checks (`CHANGELOG.md` excluded)
-- Wrap lines at 80 characters
-- Use proper heading hierarchy (no skipped levels)
-- Include language identifiers in code fences
-- Shell code blocks must also pass `shellcheck` and `shfmt`
+<!-- keep-sorted:skip -->
+Keep-sorted `start` / `end` comment markers appear in YAML
+<!-- keep-sorted:skip -->
+lists, var blocks, and `ansible.cfg`. Insertions must stay
+alphabetically sorted within the markers; do not remove the markers.
 
-## JSON Files
+## CI specifics
 
-- Must pass `jsonlint --comments` validation
-- `.devcontainer/devcontainer.json` is excluded from linting
+- `.github/workflows/macos.yml` runs on every push (not main) that
+  touches `ansible/{files,handlers,main.yml,tasks/{MacOSX,common}.yml,vars/{Darwin,common}.yml}`
+  or the workflow itself. Runs the playbook twice (apply +
+  idempotence) and fails if the second run reports any changes.
+- `.github/workflows/fedora.yml` is `workflow_dispatch` only
+  (push trigger commented out) — uses Vagrant + VirtualBox on
+  `macos-15`.
+- Full local lint pass mirroring CI: `mega-linter-runner --flavor documentation`
+  (requires Docker).
 
-## Link Checking
+## Shell wrappers
 
-- `lychee` validates URLs (config in `lychee.toml`)
-- Accepts status codes 200 and 429
-- Excludes `CHANGELOG.md`, private IPs, template variables
+The `run_ansible_my_workstation*.sh` scripts use `set -eux` and
+`cd ansible || exit`. Keep them small; real logic belongs in
+playbooks. Lint with
+`shellcheck --exclude=SC2317` and
+`shfmt --case-indent --indent 2 --space-redirects`.
 
-## Security Scanning
+## Things not to do
 
-- **Checkov**: IaC scanner (skips `CKV_GHA_7`)
-- **DevSkim**: Pattern scanner (ignores DS162092, DS137138)
-- **Trivy**: HIGH/CRITICAL severity, ignores unfixed
-
-## GitHub Actions
-
-- Pin actions to full SHA commits, never tags
-- Use minimal permissions (`permissions: read-all`)
-- Validate changes with `actionlint`
-
-## Version Control
-
-### Commit Messages
-
-Conventional commit format: `<type>: <description>`
-
-- Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`,
-  `style`, `perf`, `ci`, `build`, `revert`
-- Subject: imperative mood, lowercase, no period, max 72 chars
-- Body: wrap at 72 chars, explain what and why
-- Reference issues: `Fixes`, `Closes`, `Resolves`
-
-```text
-feat: add automated dependency updates
-
-- Implement Dependabot configuration
-- Configure weekly security updates
-
-Resolves: #123
-```
-
-### Branching
-
-Follow conventional branch format: `<type>/<description>`
-
-- `feature/` or `feat/`, `bugfix/` or `fix/`, `hotfix/`,
-  `release/`, `chore/`
-- Lowercase, hyphens only, no consecutive/trailing hyphens
-
-### Pull Requests
-
-- Always create as **draft** initially
-- Title must follow conventional commit format
-- Include clear description and link related issues
-
-## General Style
-
-- **Indentation**: 2 spaces everywhere (YAML, shell, JSON)
-- **No tabs**: Spaces only in all files
-- **Formatting**: Consistent formatting across all file types
-- **Atomic commits**: One logical change per commit
+- Don't add roles or restructure into multiple plays — current
+  design is intentionally one play, three task files.
+- Don't commit `ansible/vault-my_workstation.password` (gitignored).
+- Don't use octal file modes or short module names — lint will
+  fail.
+- Don't add tasks that change on every run without
+  `skip_idempotence_test` — CI macos job will fail.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,9 +81,7 @@ idempotence or break.
 
 ## `keep-sorted` blocks
 
-<!-- keep-sorted:skip -->
 Keep-sorted `start` / `end` comment markers appear in YAML
-<!-- keep-sorted:skip -->
 lists, var blocks, and `ansible.cfg`. Insertions must stay
 alphabetically sorted within the markers; do not remove the markers.
 

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -735,6 +735,7 @@
     key: "{{ item.key }}"
     type: "{% if item.type is defined %}{{ item.type }}{% else %}string{% endif %}"
     value: "{{ item.value }}"
+  tags: skip_idempotence_test
   loop:
     # keep-sorted start
     - key: Battery_battery_additional

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -710,11 +710,9 @@
 
 - name: Add agent skills
   ansible.builtin.command: >-
-    gh skill install {{ item.repo }}
-    {{ item.skill }}
-    --agent warp --scope user
+    gh skill install {{ item.repo }} {{ item.skill }} --agent warp --scope user --force
   args:
-    creates: ~/.agents/skills/{{ item.skill }}
+    creates: ~/.agents/skills/{{ item.name }}
   loop: "{{ code_opencode_agent_skills }}"
 
 ###################################################

--- a/ansible/vars/Darwin.yml
+++ b/ansible/vars/Darwin.yml
@@ -94,7 +94,6 @@ homebrew_packages:
   - shellcheck
   - shfmt
   - telnet
-  - tflint
   - tfupdate
   - tig
   - trivy

--- a/ansible/vars/common.yml
+++ b/ansible/vars/common.yml
@@ -27,6 +27,9 @@ code_opencode_agent_skills:
   - name: gh-address-comments
     repo: openai/skills
     skill: skills/.curated/gh-address-comments
+  - name: gh-fix-ci
+    repo: openai/skills
+    skill: skills/.curated/gh-fix-ci
   - name: git-commit
     repo: github/awesome-copilot
     skill: git-commit

--- a/ansible/vars/common.yml
+++ b/ansible/vars/common.yml
@@ -24,14 +24,27 @@ code_extensions:
 
 code_opencode_agent_skills:
   # keep-sorted start block=yes
-  - repo: anthropics/skills
-    skill: skill-creator
-  - repo: antonbabenko/terraform-skill
-    skill: terraform-skill
-  - repo: github/awesome-copilot
+  - name: gh-address-comments
+    repo: openai/skills
+    skill: skills/.curated/gh-address-comments
+  - name: git-commit
+    repo: github/awesome-copilot
     skill: git-commit
-  - repo: hashicorp/agent-skills
-    skill: terraform-style-guide
+  - name: pdf
+    repo: anthropics/skills
+    skill: pdf
+  - name: skill-creator
+    repo: anthropics/skills
+    skill: skill-creator
+  - name: terraform-skill
+    repo: antonbabenko/terraform-skill
+    skill: terraform-skill
+  - name: terraform-style-guide
+    repo: hashicorp/agent-skills
+    skill: terraform/code-generation/skills/terraform-style-guide
+  - name: terraform-test
+    repo: hashicorp/agent-skills
+    skill: terraform/code-generation/skills/terraform-test
   # keep-sorted end
 
 # Directory where there are all the data (usually $HOME)


### PR DESCRIPTION
## Summary

- Add `name` field to agent skills for correct `creates` path detection
- Add `--force` flag to skill install command
- Add new skills: gh-address-comments, pdf, terraform-test
- Update skill paths for terraform-style-guide and skill-creator
- Add vault password file pattern to `.gitignore`