### PR TITLE
chore: update macOS zsh config and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@ __pycache__/
 
 # Ansible temporary files
 ansible/.ansible/
+
+# Ansible vault password file
+vault-*.password
 # keep-sorted end

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -434,6 +434,11 @@
       # Do not share history between sessions (like bash)
       setopt NO_SHARE_HISTORY
 
+      # Allow mise caching (https://mise.jdx.dev/configuration/settings.html#env_cache)
+      export MISE_ENV_CACHE=1
+
+      # Remove the quarantine flag when it installs a package
+      export HOMEBREW_CASK_OPTS="--no-quarantine"
       # Use bat for the brew cat command
       export HOMEBREW_BAT=1
       # Cleanup all cached files older than this many days
@@ -442,6 +447,9 @@
       export HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK=1
       # Stop Homebrew auto update
       export HOMEBREW_NO_AUTO_UPDATE=1
+      export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
+
+      eval "$(/opt/homebrew/bin/brew shellenv)"
 
       # Enable homebrew, find, sed, coreutils
       MY_GENERATED_PATH=$(for BIN in ${HOMEBREW_PREFIX}/opt/*/libexec/gnubin ; do echo -n "${BIN}:"; done)
@@ -452,7 +460,7 @@
       export MANPATH="${MY_GENERATED_MAN}${MANPATH}"
 
       # Enable binaries for node, krew and ~/bin
-      export PATH="/usr/local/bin:${HOME}/.krew/bin:${HOME}/bin:${HOME}/Documents/mckinsey/bin:${HOME}/go/bin:${PATH}"
+      export PATH="/usr/local/bin:${HOME}/.krew/bin:${HOME}/bin:${HOME}/.local/bin:${HOME}/Documents/mckinsey/bin:${HOME}/go/bin:${PATH}"
       export GOPATH="${HOME}/go"
 
       # zsh-completions
@@ -499,20 +507,8 @@
 
       source "${HOMEBREW_PREFIX}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
-      source ~/Documents/secrets/secret_variables
-
       # ignore # on command line - https://unix.stackexchange.com/questions/557486/allowing-comments-in-interactive-zsh-commands
       setopt INTERACTIVE_COMMENTS
-
-      # Add highlighters to zsh-syntax-highlighting (default is 'main')
-      ZSH_HIGHLIGHT_HIGHLIGHTERS=(main brackets)
-
-      # If you don't set a sane max length the highlighter will highlight large pastes of text, which is painfully slow
-      ZSH_HIGHLIGHT_MAXLENGTH=180
-
-      # Disable underline in zsh-syntax-highlighting
-      ZSH_HIGHLIGHT_STYLES[path]=none
-      ZSH_HIGHLIGHT_STYLES[path_prefix]=none
 
       # Disable Kopia updates checks
       export KOPIA_CHECK_FOR_UPDATES=false
@@ -520,7 +516,9 @@
       # Configure DOCKER_HOST for app
       export DOCKER_HOST=unix://$HOME/.colima/docker.sock
 
-      zstyle ':completion:*' format $'\e[2;37mCompleting %d\e[m'
+      # Configure TF_PLUGIN_CACHE_DIR for Terraform / OpenTofu
+      export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
+
       source <(carapace _carapace)
 
       eval "$(atuin init zsh --disable-up-arrow)"


### PR DESCRIPTION
- Add vault password file pattern to .gitignore
- Add mise env caching and Homebrew no-quarantine options
- Add brew shellenv, HOMEBREW_NO_REQUIRE_TAP_TRUST
- Add ~/.local/bin to PATH
- Add TF_PLUGIN_CACHE_DIR for Terraform/OpenTofu
- Remove zsh-syntax-highlighting custom config
- Remove secrets source line