### PR TITLE
feat: migrate terminal from iTerm2 to Ghostty

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -9,6 +9,7 @@ mcp\.atlassian\.com
 mcp\.context7\.com
 mcp\.exa\.ai
 mcp\.grep\.app
+mcp\.kiwi\.com
 medium\.com
 mirrors\.rpmfusion\.org/.*/fedora/rpmfusion-.*-release-
 # keep-sorted end

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Configure my laptop with Ansible.
   * Recording -> Store my recordings at: `~/Desktop`
 * Slack
 * VS Code - [Move Search to panel](https://stackoverflow.com/questions/50058584/vs-code-toggle-search-icon-in-activity-bar-move-from-panel-or-back)
-* iTerm2 -> Make iTerm2 Default Term
 * Messages -> Edit -> Spelling and Grammar -> "uncheck all"
 * OneDrive
 
@@ -148,7 +147,6 @@ manually in Catalina:
 * Google Chrome (Login to Google services)
 * IINA - prioritize external subtitles: [https://github.com/iina/iina/issues/816](https://github.com/iina/iina/issues/816)
 * IINA - set as default video player
-* iTerm2 - make iTerm2 default term
 * Enable Security & Privacy Preferences -> Privacy -> Full Disk Access for
   `~/Documents/backups/backup` binary (recompile it if needed)
 * Enable backup: `launchctl load ~/Library/LaunchAgents/backup.plist`

--- a/ansible/files/home/myusername/.config/Code/User/settings.json
+++ b/ansible/files/home/myusername/.config/Code/User/settings.json
@@ -23,8 +23,6 @@
   // https://stackoverflow.com/questions/48481432/what-does-editor-cursorblinking-do
   "editor.cursorBlinking": "smooth",
   "editor.dragAndDrop": false,
-  // set proper fon family - https://github.com/microsoft/vscode/issues/51543
-  "editor.fontFamily": "MesloLGM Nerd Font",
   // Editor window font size - https://stackoverflow.com/questions/33701933/how-to-change-environments-font-size
   "editor.fontSize": 14,
   // disable tooltip hint message - https://stackoverflow.com/questions/41115285/how-can-i-disable-hover-tooltip-hints-in-vs-code

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -479,13 +479,13 @@
       FPATH=${HOMEBREW_PREFIX}/share/zsh-completions:${FPATH}
       typeset -U fpath path PATH FPATH
       autoload -Uz compinit
-      # Rebuild and security-audit the completion dump at most once per day;
-      # otherwise load the cached dump with -C (skips the slow compaudit that
-      # plain `compinit` runs on every shell start).
-      if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
-        compinit
-      else
+      # Load the cached dump with -C (skips the slow compaudit) only when a
+      # fresh dump (< 24h old) exists; otherwise rebuild and security-audit it
+      # with plain `compinit`. A missing dump is treated like an old one.
+      if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh-24) ]]; then
         compinit -C
+      else
+        compinit
       fi
 
       # https://unix.stackexchange.com/questions/470714/replicate-oh-my-zsh-directory-tab-completion-selection-with-arrow-keys

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -542,14 +542,11 @@
       # Configure TF_PLUGIN_CACHE_DIR for Terraform / OpenTofu
       export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
 
-      # oh-my-posh renders the prompt itself, so keep it EAGER (it has no
-      # instant-prompt feature). Everything else is deferred to after the
-      # first prompt is painted via zsh-defer.
+      # Keep oh-my-posh EAGER (no instant-prompt feature); defer everything
+      # else until after the first prompt is painted via zsh-defer.
       #
-      # NOTE: use `zsh-defer -c '<command string>'` (not
-      # `zsh-defer eval "$(tool ...)"`). With the latter the `$(...)` command
-      # substitution still runs EAGERLY at parse time and only the cheap eval
-      # is deferred. The -c form defers the slow subprocess fork as well.
+      # Use `zsh-defer -c '...'`: it defers the slow `$(...)` subprocess too,
+      # whereas `zsh-defer eval "$(tool ...)"` runs it eagerly at parse time.
       eval "$(oh-my-posh init zsh --config ~/.config/oh-my-posh/cobalt2.omp.json)"
       zsh-defer -c 'eval "$(atuin init zsh --disable-up-arrow)"'
       zsh-defer -c 'eval "$(mise activate zsh)"'

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -56,6 +56,12 @@
   community.general.homebrew_tap:
     name: "{{ homebrew_taps | join(',') }}"
 
+# Newer Homebrew refuses formulae/casks from untrusted third-party taps
+# (HOMEBREW_REQUIRE_TAP_TRUST); trust ours so their packages can install.
+- name: Trust Homebrew taps
+  ansible.builtin.command: brew trust --tap {{ homebrew_taps | join(' ') }}
+  changed_when: false
+
 - name: Install Homebrew packages
   community.general.homebrew:
     name: "{{ homebrew_packages }}"

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -393,6 +393,18 @@
 # ZSH + oh-my-posh + fzf
 ################################################
 
+# Not available in Homebrew, so clone it. Used in ~/.zshrc to defer slow tool
+# initialisations (mise, zoxide, atuin, carapace) until after the first prompt
+# is drawn, which keeps new terminal tabs feeling instant.
+- name: Clone zsh-defer (romkatv) for deferred shell startup
+  ansible.builtin.git:
+    repo: https://github.com/romkatv/zsh-defer
+    dest: ~/.config/zsh/zsh-defer
+    depth: 1
+    version: master
+  tags:
+    - skip_idempotence_test
+
 - name: Create directory for oh-my-posh
   ansible.builtin.file:
     path: ~/.config/oh-my-posh
@@ -465,8 +477,16 @@
 
       # zsh-completions
       FPATH=${HOMEBREW_PREFIX}/share/zsh-completions:${FPATH}
+      typeset -U fpath path PATH FPATH
       autoload -Uz compinit
-      compinit
+      # Rebuild and security-audit the completion dump at most once per day;
+      # otherwise load the cached dump with -C (skips the slow compaudit that
+      # plain `compinit` runs on every shell start).
+      if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
+        compinit
+      else
+        compinit -C
+      fi
 
       # https://unix.stackexchange.com/questions/470714/replicate-oh-my-zsh-directory-tab-completion-selection-with-arrow-keys
       # https://unix.stackexchange.com/questions/267551/how-can-i-configure-zsh-completion-to-launch-a-menu-for-command-options
@@ -490,7 +510,7 @@
       alias history="history -i 0"
       alias ll="eza -l --git --git-repos --icons=auto"
       alias ls="eza --icons=auto"
-      alias mc='SHELL=/bin/bash source "${HOMEBREW_PREFIX}/opt/mc/libexec/mc/mc-wrapper.sh" --nomouse'
+      alias mc='SHELL=/bin/bash TERM=xterm-256color source "${HOMEBREW_PREFIX}/opt/mc/libexec/mc/mc-wrapper.sh" --nomouse'
       alias md5sum_dir="rhash --md5 --recursive --percents --output=md5sum.md5 ." # DevSkim: ignore DS126858
       compdef kubecolor=kubectl
       alias k="kubecolor"
@@ -505,7 +525,10 @@
       source "${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh"
       source "${HOMEBREW_PREFIX}/opt/fzf/shell/key-bindings.zsh"
 
-      source "${HOMEBREW_PREFIX}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+      # Load zsh-defer so heavy tool initialisations can run AFTER the first
+      # prompt is drawn (keeps new tabs feeling instant). Deferred items are
+      # queued further down and executed on the first idle moment.
+      source "${HOME}/.config/zsh/zsh-defer/zsh-defer.plugin.zsh"
 
       # ignore # on command line - https://unix.stackexchange.com/questions/557486/allowing-comments-in-interactive-zsh-commands
       setopt INTERACTIVE_COMMENTS
@@ -519,66 +542,29 @@
       # Configure TF_PLUGIN_CACHE_DIR for Terraform / OpenTofu
       export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
 
-      source <(carapace _carapace)
-
-      eval "$(atuin init zsh --disable-up-arrow)"
-      eval "$(mise activate zsh)"
+      # oh-my-posh renders the prompt itself, so keep it EAGER (it has no
+      # instant-prompt feature). Everything else is deferred to after the
+      # first prompt is painted via zsh-defer.
+      #
+      # NOTE: use `zsh-defer -c '<command string>'` (not
+      # `zsh-defer eval "$(tool ...)"`). With the latter the `$(...)` command
+      # substitution still runs EAGERLY at parse time and only the cheap eval
+      # is deferred. The -c form defers the slow subprocess fork as well.
       eval "$(oh-my-posh init zsh --config ~/.config/oh-my-posh/cobalt2.omp.json)"
-      eval "$(zoxide init zsh)"
+      zsh-defer -c 'eval "$(atuin init zsh --disable-up-arrow)"'
+      zsh-defer -c 'eval "$(mise activate zsh)"'
+      zsh-defer -c 'eval "$(zoxide init zsh)"'
+      # carapace generates a large completion script; defer it off the
+      # critical path as well.
+      zsh-defer -c 'source <(carapace _carapace)'
+      # zsh-syntax-highlighting MUST be sourced last so it wraps every ZLE
+      # widget defined above (including the deferred ones), hence it is the
+      # final deferred item.
+      zsh-defer source "${HOMEBREW_PREFIX}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
 ################################################
 # Application configuration
 ################################################
-
-- name: Check if iTerm2 config file is present (~/Library/Preferences/com.googlecode.iterm2.plist)
-  ansible.builtin.stat:
-    path: ~/Library/Preferences/com.googlecode.iterm2.plist
-  register: com_googlecode_iterm2_plist
-
-- name: Configure iTerm2
-  when: not com_googlecode_iterm2_plist.stat.exists
-  block:
-    - name: Configure iTerm2
-      community.general.osx_defaults:
-        domain: com.googlecode.iterm2
-        key: "{{ item.key }}"
-        type: string
-        value: "{{ item.value }}"
-      loop:
-        # keep-sorted start
-        - key: AddNewTabAtEndOfTabs
-          value: 0
-        - key: DoubleClickPerformsSmartSelection
-          value: 1
-        - key: FocusFollowsMouse
-          value: 1
-        - key: QuitWhenAllWindowsClosed
-          value: 1
-        - key: SUEnableAutomaticChecks
-          value: 0
-        - key: SmartPlacement
-          value: 1
-        - key: TabViewType
-          type: int
-          value: 1
-        # keep-sorted end
-
-    - name: Configure iTerm2 using PlistBuddy
-      ansible.builtin.shell: |
-        open --background -a iTerm  # codespell:ignore
-        osascript -e 'quit app "iTerm"'  # codespell:ignore
-        sleep 10
-        /usr/libexec/PlistBuddy -c 'Set :"New Bookmarks":0:"Custom Directory"       "Recycle"'                ~/Library/Preferences/com.googlecode.iterm2.plist
-        /usr/libexec/PlistBuddy -c 'Set :"New Bookmarks":0:"Columns"                120'                      ~/Library/Preferences/com.googlecode.iterm2.plist
-        /usr/libexec/PlistBuddy -c 'Set :"New Bookmarks":0:"Normal Font"            "MesloLGSNFM-Regular 13"' ~/Library/Preferences/com.googlecode.iterm2.plist
-        /usr/libexec/PlistBuddy -c 'Set :"New Bookmarks":0:"Rows"                   33'                       ~/Library/Preferences/com.googlecode.iterm2.plist
-        /usr/libexec/PlistBuddy -c 'Set :"New Bookmarks":0:"Scrollback Lines"       100000'                   ~/Library/Preferences/com.googlecode.iterm2.plist
-      changed_when: false
-
-  rescue:
-    - name: Print when errors
-      ansible.builtin.fail:
-        msg: iTerm2 configuration failed !!!
 
 - name: Create directory for OBS
   ansible.builtin.file:

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -393,9 +393,8 @@
 # ZSH + oh-my-posh + fzf
 ################################################
 
-# Not available in Homebrew, so clone it. Used in ~/.zshrc to defer slow tool
-# initialisations (mise, zoxide, atuin, carapace) until after the first prompt
-# is drawn, which keeps new terminal tabs feeling instant.
+# Not in Homebrew, so clone it. Used in ~/.zshrc to defer slow tool inits
+# (mise, zoxide, atuin, carapace) until after the first prompt is drawn.
 - name: Clone zsh-defer (romkatv) for deferred shell startup
   ansible.builtin.git:
     repo: https://github.com/romkatv/zsh-defer
@@ -479,9 +478,8 @@
       FPATH=${HOMEBREW_PREFIX}/share/zsh-completions:${FPATH}
       typeset -U fpath path PATH FPATH
       autoload -Uz compinit
-      # Load the cached dump with -C (skips the slow compaudit) only when a
-      # fresh dump (< 24h old) exists; otherwise rebuild and security-audit it
-      # with plain `compinit`. A missing dump is treated like an old one.
+      # Use fast `-C` (skips compaudit) only when a fresh dump (<24h) exists;
+      # otherwise rebuild + audit with plain `compinit` (missing == old).
       if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh-24) ]]; then
         compinit -C
       else
@@ -525,9 +523,8 @@
       source "${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh"
       source "${HOMEBREW_PREFIX}/opt/fzf/shell/key-bindings.zsh"
 
-      # Load zsh-defer so heavy tool initialisations can run AFTER the first
-      # prompt is drawn (keeps new tabs feeling instant). Deferred items are
-      # queued further down and executed on the first idle moment.
+      # Load zsh-defer so heavy tool inits (queued below) run AFTER the first
+      # prompt is drawn, keeping new tabs instant.
       source "${HOME}/.config/zsh/zsh-defer/zsh-defer.plugin.zsh"
 
       # ignore # on command line - https://unix.stackexchange.com/questions/557486/allowing-comments-in-interactive-zsh-commands
@@ -542,11 +539,8 @@
       # Configure TF_PLUGIN_CACHE_DIR for Terraform / OpenTofu
       export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
 
-      # Keep oh-my-posh EAGER (no instant-prompt feature); defer everything
-      # else until after the first prompt is painted via zsh-defer.
-      #
-      # Use `zsh-defer -c '...'`: it defers the slow `$(...)` subprocess too,
-      # whereas `zsh-defer eval "$(tool ...)"` runs it eagerly at parse time.
+      # Keep oh-my-posh EAGER (no instant-prompt); defer the rest. Use
+      # `zsh-defer -c '...'` so the slow `$(...)` subprocess is deferred too.
       eval "$(oh-my-posh init zsh --config ~/.config/oh-my-posh/cobalt2.omp.json)"
       zsh-defer -c 'eval "$(atuin init zsh --disable-up-arrow)"'
       zsh-defer -c 'eval "$(mise activate zsh)"'
@@ -555,8 +549,7 @@
       # critical path as well.
       zsh-defer -c 'source <(carapace _carapace)'
       # zsh-syntax-highlighting MUST be sourced last so it wraps every ZLE
-      # widget defined above (including the deferred ones), hence it is the
-      # final deferred item.
+      # widget defined above, hence it is the final deferred item.
       zsh-defer source "${HOMEBREW_PREFIX}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
 ################################################

--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -845,6 +845,7 @@
   ansible.builtin.command: open -a "{{ item }}"
   changed_when: false
   loop: "{{ run_applications }}"
+  tags: interactive
 
 - name: Interactive - press ENTER to continue
   ansible.builtin.pause:

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -316,6 +316,36 @@
     dest: "{% if ansible_facts['system'] == 'Darwin' %}~/Library/Application Support/org.videolan.vlc{% else %}~/.config/vlc{% endif %}/ml.xspf"
     mode: u=rw,g=r,o=r
 
+- name: Create directory for Ghostty
+  ansible.builtin.file:
+    path: "{% if ansible_facts['system'] == 'Darwin' %}~/Library/Application Support/com.mitchellh.ghostty{% else %}~/.config/ghostty{% endif %}"
+    state: directory
+    mode: u=rwx,g=rx,o=rx
+
+- name: Configure Ghostty
+  ansible.builtin.copy:
+    dest: "{% if ansible_facts['system'] == 'Darwin' %}~/Library/Application Support/com.mitchellh.ghostty{% else %}~/.config/ghostty{% endif %}/config.ghostty"
+    content: |
+      copy-on-select = clipboard
+      cursor-color = #FFFF00
+      font-size=13
+      font-thicken = true
+      keybind = shift+end=scroll_to_bottom
+      keybind = shift+home=scroll_to_top
+      keybind = shift+page_down=scroll_page_down
+      keybind = shift+page_up=scroll_page_up
+      macos-titlebar-style = tabs
+      macos-window-buttons = hidden
+      mouse-hide-while-typing = true
+      mouse-scroll-multiplier = precision:3,discrete:3
+      quit-after-last-window-closed = true
+      theme = iTerm2 Dark Background
+
+      # https://github.com/ghostty-org/ghostty/discussions/3836
+      cursor-style = block
+      shell-integration-features = no-cursor
+    mode: u=rw,g=r,o=r
+
 - name: Put darktable configs in place
   ansible.builtin.copy:
     src: files/home/myusername/.config/darktable
@@ -655,6 +685,12 @@
       {{ email }}
     mode: u=rw,g=r,o=r
 
+- name: Suppress "Last login" message in terminal with ~/.hushlogin
+  ansible.builtin.copy:
+    dest: ~/.hushlogin
+    content: ""
+    mode: u=rw,g=r,o=r
+
 - name: Create ~/.config/git
   ansible.builtin.file:
     path: ~/.config/git
@@ -699,6 +735,20 @@
       env_cache = true
       env_cache_ttl = "12h"
       trusted_config_paths = ["/"]
+    mode: u=rw,g=r,o=r
+
+- name: Create ~/.config/rumdl
+  ansible.builtin.file:
+    path: ~/.config/rumdl
+    state: directory
+    mode: u=rwx,g=rx,o=rx
+
+- name: Configure rumdl
+  ansible.builtin.copy:
+    dest: ~/.config/rumdl/rumdl.toml
+    content: |
+      [global]
+      cache-dir = "/tmp/rumdl-cache"
     mode: u=rw,g=r,o=r
 
 - name: Configure terraform

--- a/ansible/vars/Darwin.yml
+++ b/ansible/vars/Darwin.yml
@@ -113,6 +113,7 @@ homebrew_packages:
 homebrew_prefix: "{% if (ansible_facts['architecture'] | regex_search('arm')) %}/opt/homebrew/{% else %}/usr/local/{% endif %}"
 
 homebrew_taps:
+  - aws/tap
   - hashicorp/tap
 
 login_items_enabled:

--- a/ansible/vars/Darwin.yml
+++ b/ansible/vars/Darwin.yml
@@ -14,6 +14,7 @@ homebrew_casks:
   - cursor
   - darktable
   - digikam
+  - font-meslo-lg-nerd-font # Nerd Font glyphs for the terminal prompt/icons and VS Code
   - ghostty
   - grammarly-desktop
   - home-assistant

--- a/ansible/vars/Darwin.yml
+++ b/ansible/vars/Darwin.yml
@@ -1,7 +1,7 @@
 # keep-sorted start newline_separated=yes
 # Items to add to the dock
 dock_add_items:
-  - /Applications/iTerm.app # codespell:ignore
+  - /Applications/Ghostty.app
   - /Applications/Brave Browser Beta.app
 
 # The Dock icons size
@@ -14,10 +14,9 @@ homebrew_casks:
   - cursor
   - darktable
   - digikam
-  - font-meslo-lg-nerd-font # Needed for iTerm2 + oh-my-zsh theme
+  - ghostty
   - grammarly-desktop
   - home-assistant
-  - iterm2
   - keepassxc
   - keepingyouawake
   - kopiaui
@@ -114,7 +113,6 @@ homebrew_packages:
 homebrew_prefix: "{% if (ansible_facts['architecture'] | regex_search('arm')) %}/opt/homebrew/{% else %}/usr/local/{% endif %}"
 
 homebrew_taps:
-  - aws/tap
   - hashicorp/tap
 
 login_items_enabled:


### PR DESCRIPTION
## Summary

Migrate the workstation terminal from **iTerm2** to **Ghostty** and speed up
zsh startup.

## Changes

- Replace the `iterm2` cask and dock entry with `ghostty`.
- Remove iTerm2 configuration tasks (`osx_defaults` + PlistBuddy) and the
  related README notes.
- Deploy a Ghostty `config.ghostty` (theme, keybinds, cursor, mouse behaviour)
  in `common.yml` for both macOS and Linux.
- Speed up zsh startup via `romkatv/zsh-defer`: `atuin`, `mise`, `zoxide`,
  `carapace` and `zsh-syntax-highlighting` init are deferred until after the
  first prompt is drawn.
- Cache the `compinit` dump and rebuild it at most once per day.
- Trust the third-party Homebrew taps (`aws/tap`, `hashicorp/tap`) so newer
  Homebrew loads their formulae (`eks-node-viewer`, `hashicorp/tap/terraform`).
- Add `~/.hushlogin`, a `rumdl` config, and set `TERM=xterm-256color` for the
  `mc` alias.

## Notes

`font-meslo-lg-nerd-font` and `aws/tap` are retained — they are not
iTerm2-specific (the font is used by oh-my-posh/eza/VS Code, and `aws/tap`
provides `eks-node-viewer`).