### PR TITLE
feat: add zsh-patina and refine macOS shell and Ghostty config

### DIFF
--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -410,6 +410,20 @@
   tags:
     - skip_idempotence_test
 
+- name: Create directory for zsh-patina inside ~/.config
+  ansible.builtin.file:
+    path: ~/.config/zsh-patina
+    state: directory
+    mode: u=rwx,g=rx,o=rx
+
+- name: Copy zsh-patina config.toml
+  ansible.builtin.copy:
+    content: |
+      [highlighting]
+      theme = "tokyonight"
+    dest: ~/.config/zsh-patina/config.toml
+    mode: u=rw,g=r,o=r
+
 - name: Create directory for oh-my-posh
   ansible.builtin.file:
     path: ~/.config/oh-my-posh
@@ -540,10 +554,13 @@
       export KOPIA_CHECK_FOR_UPDATES=false
 
       # Configure DOCKER_HOST for app
-      export DOCKER_HOST=unix://$HOME/.colima/docker.sock
+      export DOCKER_HOST=unix://${HOME}/.colima/docker.sock
 
       # Configure TF_PLUGIN_CACHE_DIR for Terraform / OpenTofu
       export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
+
+      # Configure RUMDL_CACHE_DIR for rumdl
+      export RUMDL_CACHE_DIR="${HOME}/.cache/rumdl-cache"
 
       # Keep oh-my-posh EAGER (no instant-prompt); defer the rest. Use
       # `zsh-defer -c '...'` so the slow `$(...)` subprocess is deferred too.
@@ -551,6 +568,7 @@
       zsh-defer -c 'eval "$(atuin init zsh --disable-up-arrow)"'
       zsh-defer -c 'eval "$(mise activate zsh)"'
       zsh-defer -c 'eval "$(zoxide init zsh)"'
+      zsh-defer -c 'eval "$(${HOMEBREW_PREFIX}/bin/zsh-patina activate)"'
       # carapace generates a large completion script; defer it off the
       # critical path as well.
       zsh-defer -c 'source <(carapace _carapace)'

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -330,7 +330,7 @@
       copy-on-select = clipboard
       cursor-color = #FFFF00
       font-feature = -calt, -liga, -dlig
-      font-size=14
+      font-size = 14
       font-thicken = true
       keybind = cmd+shift+left=move_tab:-1
       keybind = cmd+shift+right=move_tab:1

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -318,18 +318,22 @@
 
 - name: Create directory for Ghostty
   ansible.builtin.file:
-    path: "{% if ansible_facts['system'] == 'Darwin' %}~/Library/Application Support/com.mitchellh.ghostty{% else %}~/.config/ghostty{% endif %}"
+    path: ~/.config/ghostty
     state: directory
     mode: u=rwx,g=rx,o=rx
 
 - name: Configure Ghostty
   ansible.builtin.copy:
-    dest: "{% if ansible_facts['system'] == 'Darwin' %}~/Library/Application Support/com.mitchellh.ghostty{% else %}~/.config/ghostty{% endif %}/config.ghostty"
+    dest: ~/.config/ghostty/config.ghostty
     content: |
+      auto-update = off
       copy-on-select = clipboard
       cursor-color = #FFFF00
-      font-size=13
+      font-feature = -calt, -liga, -dlig
+      font-size=14
       font-thicken = true
+      keybind = cmd+shift+left=move_tab:-1
+      keybind = cmd+shift+right=move_tab:1
       keybind = shift+end=scroll_to_bottom
       keybind = shift+home=scroll_to_top
       keybind = shift+page_down=scroll_page_down
@@ -339,7 +343,11 @@
       mouse-hide-while-typing = true
       mouse-scroll-multiplier = precision:3,discrete:3
       quit-after-last-window-closed = true
+      split-divider-color = green
       theme = iTerm2 Dark Background
+      unfocused-split-opacity = 0.8
+      window-height = 50
+      window-width = 183
 
       # https://github.com/ghostty-org/ghostty/discussions/3836
       cursor-style = block

--- a/ansible/vars/Darwin.yml
+++ b/ansible/vars/Darwin.yml
@@ -40,8 +40,9 @@ homebrew_packages:
   - azure-cli
   - bash
   - bat
+  - betterleaks # pre-commit hook
   - carapace
-  - checkov # needs gcc, openblas
+  - checkov # needs gcc, openblas; pre-commit hook (terraform_checkov)
   - cilium-cli
   - cloudflared # needed for ssh with cloudflare tunnels
   - codeburn
@@ -65,7 +66,7 @@ homebrew_packages:
   - gnu-tar
   - gnupg
   - grep
-  - hashicorp/tap/terraform
+  - hashicorp/tap/terraform # pre-commit hook (terraform_fmt, terraform_validate)
   - helm
   - htop
   - imagemagick
@@ -73,7 +74,7 @@ homebrew_packages:
   - iproute2mac
   - jq
   - k9s
-  - keep-sorted
+  - keep-sorted # pre-commit hook
   - kind
   - kopia
   - krew
@@ -86,24 +87,24 @@ homebrew_packages:
   - oh-my-posh
   - opencode
   - opentofu
-  - prek
-  - prettier
+  - prek # runs the pre-commit config
+  - prettier # pre-commit hook
   - rclone
   - rhash
   - rmtrash
   - rsync
-  - shellcheck
-  - shfmt
+  - shellcheck # pre-commit hook
+  - shfmt # pre-commit hook
   - telnet
-  - tfupdate
+  - tfupdate # pre-commit hook
   - tig
-  - trivy
+  - trivy # pre-commit hook (terraform_trivy)
   - uutils-coreutils
   - uutils-diffutils
   - uutils-findutils
   - watch
   - wget
-  - yamllint
+  - yamllint # pre-commit hook
   - yq
   - yt-dlp
   - zoxide


### PR DESCRIPTION
## Summary

- Integrate **zsh-patina** with a `tokyonight` highlighting theme (new
  `~/.config/zsh-patina/config.toml` and deferred activation in zsh)
- Add `RUMDL_CACHE_DIR` to the zsh environment
- Expand the **Ghostty** config (auto-update off, `cmd+shift+left/right`
  tab-move keybinds, split divider/opacity colors, window sizing, font
  features) and move the config to `~/.config/ghostty` on all platforms
- Add the `betterleaks` package and annotate which Homebrew packages are
  used as pre-commit hooks

## Motivation

Personal workstation config tweaks for the macOS shell and terminal setup.