### PR TITLE
chore: remove unused macOS apps and use zsh-patina from core

### DIFF
--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -572,85 +572,10 @@
       # carapace generates a large completion script; defer it off the
       # critical path as well.
       zsh-defer -c 'source <(carapace _carapace)'
-      # zsh-syntax-highlighting MUST be sourced last so it wraps every ZLE
-      # widget defined above, hence it is the final deferred item.
-      zsh-defer source "${HOMEBREW_PREFIX}/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
 
 ################################################
 # Application configuration
 ################################################
-
-- name: Create directory for OBS
-  ansible.builtin.file:
-    path: ~/Library/Application Support/obs-studio/basic/profiles/Untitled
-    state: directory
-    mode: u=rwx,g=rx,o=rx
-
-- name: Configure OBS
-  community.general.ini_file:
-    path: ~/Library/Application Support/obs-studio/global.ini
-    no_extra_spaces: true
-    section: "{{ item.section }}"
-    option: "{{ item.option }}"
-    value: "{{ item.value }}"
-    mode: u=rw,g=r,o=r
-  loop:
-    # keep-sorted start
-    - section: BasicWindow
-      option: RecordWhenStreaming
-      value: "true"
-    - section: BasicWindow
-      option: SysTrayMinimizeToTray
-      value: "true"
-    - section: General
-      option: EnableAutoUpdates
-      value: "false"
-    - section: General
-      option: FirstRun
-      value: "true"
-    - section: General
-      option: LastVersion
-      value: 503316482
-    - section: General
-      option: WarnBeforeStartingStream
-      value: "true"
-    # keep-sorted end
-
-- name: Configure OBS default profile
-  community.general.ini_file:
-    path: ~/Library/Application Support/obs-studio/basic/profiles/Untitled/basic.ini
-    no_extra_spaces: true
-    section: "{{ item.section }}"
-    option: "{{ item.option }}"
-    value: "{{ item.value }}"
-    mode: u=rw,g=r,o=r
-  loop:
-    # keep-sorted start
-    - section: AdvOut
-      option: Encoder
-      value: com.apple.videotoolbox.videoencoder.ave.avc
-    - section: AdvOut
-      option: RecFilePath
-      value: "{{ ansible_facts['user_dir'] }}/Desktop"
-    - section: AdvOut
-      option: RecFormat
-      value: mp4
-    - section: AdvOut
-      option: Track1Bitrate
-      value: 128
-    - section: Audio
-      option: ChannelSetup
-      value: Mono
-    - section: Audio
-      option: SampleRate
-      value: 44100
-    - section: Output
-      option: Mode
-      value: Advanced
-    - section: SimpleOutput
-      option: FileNameWithoutSpace
-      value: "true"
-    # keep-sorted end
 
 - name: Configure Kopia
   ansible.builtin.copy:
@@ -685,37 +610,6 @@
       /node_modules
       # keep-sorted end
     mode: u=rw,g=r,o=r
-
-- name: Configure AltTab
-  community.general.osx_defaults:
-    domain: com.lwouis.alt-tab-macos
-    key: "{{ item.key }}"
-    type: string
-    value: "{{ item.value }}"
-  loop:
-    # keep-sorted start
-    - key: fadeOutAnimation
-      value: "true"
-    - key: hideSpaceNumberLabels
-      value: "true"
-    - key: hideStatusIcons
-      value: "true"
-    - key: hideWindowlessApps
-      value: "true"
-    - key: holdShortcut
-      value: "\u2318"
-    - key: iconSize
-      value: 20
-    - key: menubarIcon
-      value: 3
-    - key: previewFocusedWindow
-      value: "true"
-    - key: screensToShow
-      value: 1
-    - key: updatePolicy
-      value: 0
-    # keep-sorted end
-  tags: skip_idempotence_test
 
 # https://frederic-hemberger.de/notes/getting-the-latest-release-on-github-with-ansible/
 - name: Get latest release of Stats

--- a/ansible/vars/Darwin.yml
+++ b/ansible/vars/Darwin.yml
@@ -9,21 +9,17 @@ dock_icons_size: 36.0
 
 homebrew_casks:
   # keep-sorted start
-  - alt-tab
   - brave-browser@beta
   - cursor
   - darktable
   - digikam
   - font-meslo-lg-nerd-font # Nerd Font glyphs for the terminal prompt/icons and VS Code
   - ghostty
-  - grammarly-desktop
   - home-assistant
   - keepassxc
-  - keepingyouawake
   - kopiaui
   - mpv
   - mysides # Application for managing OS X Finder sidebar favorites
-  - obs
   - stats
   - thaw
   - utm
@@ -100,7 +96,6 @@ homebrew_packages:
   - tig
   - trivy # pre-commit hook (terraform_trivy)
   - uutils-coreutils
-  - uutils-diffutils
   - uutils-findutils
   - watch
   - wget
@@ -109,7 +104,7 @@ homebrew_packages:
   - yt-dlp
   - zoxide
   - zsh-completions
-  - zsh-syntax-highlighting
+  - zsh-patina
   # keep-sorted end
 
 homebrew_prefix: "{% if (ansible_facts['architecture'] | regex_search('arm')) %}/opt/homebrew/{% else %}/usr/local/{% endif %}"
@@ -120,7 +115,6 @@ homebrew_taps:
 
 login_items_enabled:
   # keep-sorted start
-  - AltTab
   - KeePassXC
   - Stats
   - Thaw
@@ -129,6 +123,5 @@ login_items_enabled:
 login_picture_url: https://www.gravatar.com/avatar/{{ email | hash('md5') }}?s=500 # DevSkim: ignore DS126858
 
 run_applications:
-  - AltTab
   - Stats
 # keep-sorted end


### PR DESCRIPTION
## Summary

Cleans up no-longer-used Homebrew casks/formulae and their associated
configuration on macOS, and installs `zsh-patina` from Homebrew core
instead of the `michel-kraemer/zsh-patina` tap.

## Changes

**`ansible/vars/Darwin.yml`**
- Removed casks: `alt-tab`, `grammarly-desktop`, `keepingyouawake`, `obs`
- Removed formulae: `uutils-diffutils`, `zsh-syntax-highlighting`
- Removed `AltTab` from `login_items_enabled` and `run_applications`
- Added `zsh-patina` to `homebrew_packages` (from core, no tap needed)

**`ansible/tasks/MacOSX.yml`**
- Removed the `zsh-syntax-highlighting` sourcing from `.zshrc`
- Removed the OBS directory/config tasks
- Removed the `Configure AltTab` task