### PR TITLE
feat: add Claude Code configuration for macOS

### DIFF
--- a/ansible/tasks/MacOSX.yml
+++ b/ansible/tasks/MacOSX.yml
@@ -525,6 +525,7 @@
       bindkey '\e[F'    end-of-line # End
 
       alias cat="bat --style=plain --paging=never"
+      alias cl="claude --permission-mode acceptEdits"
       alias dos2unix="sed -i 's/\r$//'"
       alias history="history -i 0"
       alias ll="eza -l --git --git-repos --icons=auto"

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -774,7 +774,7 @@
 
 - name: Download oh-my-posh blazed theme for Claude Code
   ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/refs/heads/main/themes/blazed.omp.json
+    url: https://raw.githubusercontent.com/josheche/blazed-omp/main/blazed.omp.json
     dest: ~/.claude/blazed.omp.json
     mode: u=rw,g=r,o=r
 

--- a/ansible/tasks/common.yml
+++ b/ansible/tasks/common.yml
@@ -766,6 +766,81 @@
       plugin_cache_dir = "${HOME}/.terraform.d/plugin-cache"
     mode: u=rw,g=r,o=r
 
+- name: Create ~/.claude directory
+  ansible.builtin.file:
+    path: ~/.claude
+    state: directory
+    mode: u=rwx,g=rx,o=rx
+
+- name: Download oh-my-posh blazed theme for Claude Code
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/refs/heads/main/themes/blazed.omp.json
+    dest: ~/.claude/blazed.omp.json
+    mode: u=rw,g=r,o=r
+
+- name: Configure Claude Code
+  ansible.builtin.copy:
+    dest: ~/.claude/settings.json
+    content: |
+      {
+        "attribution": {
+          "commit": "",
+          "pr": ""
+        },
+        "permissions": {
+          "allow": [
+            "Bash(*)",
+            "Read(*)",
+            "Edit(*)",
+            "Write(*)",
+            "Glob(*)",
+            "Grep(*)"
+          ],
+          "ask": [
+            "Bash(rm -rf:*)",
+            "Bash(rm -fr:*)",
+            "Read(.env)",
+            "Read(.env.*)",
+            "Read(**/.env)",
+            "Read(**/.env.*)",
+            "Read(~/.ssh/**)",
+            "Read(~/.aws/**)",
+            "Read(**/*credential*)",
+            "Read(**/*secret*)",
+            "Read(**/*.pem)",
+            "Read(**/*.key)"
+          ]
+        },
+        "env": {
+          "IS_DEMO": "1"
+        },
+        "model": "opus[1m]",
+        "statusLine": {
+          "type": "command",
+          "command": "oh-my-posh claude --config ~/.claude/blazed.omp.json"
+        },
+        "enabledPlugins": {
+          "code-review@claude-plugins-official": true,
+          "context7@claude-plugins-official": true,
+          "skill-creator@claude-plugins-official": true,
+          "superpowers@claude-plugins-official": true
+        },
+        "skipDangerousModePermissionPrompt": true,
+        "spinnerTipsEnabled": false,
+        "alwaysThinkingEnabled": true,
+        "effortLevel": "high"
+      }
+    mode: u=rw,g=r,o=r
+
+- name: Configure ~/.claude.json
+  ansible.builtin.copy:
+    dest: ~/.claude.json
+    content: |
+      {
+        "hasTrustDialogAccepted": true
+      }
+    mode: u=rw,g=,o=
+
 - name: Add agent skills
   ansible.builtin.command: >-
     gh skill install {{ item.repo }} {{ item.skill }} --agent warp --scope user --allow-hidden-dirs --force

--- a/ansible/vars/Darwin.yml
+++ b/ansible/vars/Darwin.yml
@@ -10,6 +10,7 @@ dock_icons_size: 36.0
 homebrew_casks:
   # keep-sorted start
   - brave-browser@beta
+  - claude-code
   - cursor
   - darktable
   - digikam


### PR DESCRIPTION
## Summary

- Add `~/.claude` directory creation and download the oh-my-posh `blazed` theme for the Claude Code statusline
- Configure `~/.claude/settings.json` (permissions, model, statusline, enabled plugins, effort level) and `~/.claude.json` (trust dialog accepted)
- Add a `cl` shell alias for `claude --permission-mode acceptEdits` on macOS

## Test plan

- [x] Run the Ansible playbook and confirm `~/.claude/settings.json`, `~/.claude.json`, and `~/.claude/blazed.omp.json` are created
- [x] Verify the `cl` alias works in a new zsh session