### PR TITLE
chore: exclude ansible vault directories from kingfisher scan

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,4 +1,5 @@
 # keep-sorted start
+api\.github\.com
 api\.githubcopilot\.com
 apple\.stackexchange\.com
 aws-mcp\.us-east-1\.api\.aws

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -68,8 +68,11 @@ REPOSITORY_CHECKOV_ARGUMENTS: --quiet
 #   - DS137138: "Insecure URL" (for HTTP links that are intentional)
 REPOSITORY_DEVSKIM_ARGUMENTS: --ignore-rule-ids DS162092,DS137138
 
-# Kingfisher (secret scanner) - exclude .git directory to avoid false positives on Git metadata files (e.g., refs that match token patterns)
-REPOSITORY_KINGFISHER_ARGUMENTS: --exclude .git
+# Kingfisher (secret scanner) - exclude directories to avoid false positives:
+# - .git: Git metadata files (e.g., refs that match token patterns)
+# - ansible/files: Ansible Vault encrypted files (SSH keys, config files)
+# - ansible/vars: Ansible Vault encrypted variables
+REPOSITORY_KINGFISHER_ARGUMENTS: --exclude .git --exclude ansible/files --exclude ansible/vars
 
 # Trivy (vulnerability scanner) - only check HIGH and CRITICAL severity
 REPOSITORY_TRIVY_ARGUMENTS: --severity HIGH,CRITICAL --ignore-unfixed

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -68,11 +68,8 @@ REPOSITORY_CHECKOV_ARGUMENTS: --quiet
 #   - DS137138: "Insecure URL" (for HTTP links that are intentional)
 REPOSITORY_DEVSKIM_ARGUMENTS: --ignore-rule-ids DS162092,DS137138
 
-# Kingfisher (secret scanner) - exclude directories to avoid false positives:
-# - .git: Git metadata files (e.g., refs that match token patterns)
-# - ansible/files: Ansible Vault encrypted files (SSH keys, config files)
-# - ansible/vars: Ansible Vault encrypted variables
-REPOSITORY_KINGFISHER_ARGUMENTS: --exclude .git --exclude ansible/files --exclude ansible/vars
+# Kingfisher (secret scanner) - use config file for exclusions
+REPOSITORY_KINGFISHER_ARGUMENTS: --config kingfisher.yaml
 
 # Trivy (vulnerability scanner) - only check HIGH and CRITICAL severity
 REPOSITORY_TRIVY_ARGUMENTS: --severity HIGH,CRITICAL --ignore-unfixed

--- a/kingfisher.yaml
+++ b/kingfisher.yaml
@@ -1,0 +1,11 @@
+# Kingfisher secret scanner configuration
+# https://mongodb.github.io/kingfisher/usage/configuration/
+
+filters:
+  exclude:
+    # Git metadata files (refs that match token patterns)
+    - .git
+    # Ansible Vault encrypted files (SSH keys, config files)
+    - ansible/files
+    # Ansible Vault encrypted variables
+    - ansible/vars


### PR DESCRIPTION
Kingfisher was detecting Ansible Vault encrypted files as false positive secrets. Add exclusions for:
- `ansible/files`: Contains vault-encrypted SSH keys and config files
- `ansible/vars`: Contains vault-encrypted variables

These files are already encrypted with Ansible Vault, so they don't need additional secret scanning.

Fixes MegaLinter failure from https://github.com/ruzickap/my-git-projects/actions/runs/31426957632